### PR TITLE
Swapped JCON 2026 to open as the CfP is now active.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Missing a conference, seeing an issue or something needs an update? Send a pull 
 | [JavaOne](https://www.oracle.com/javaone/) | Bay Area, CA, USA | no | 17–19 March 2026 | - |
 | [Voxxed Days Zurich](https://zurich.voxxeddays.com/) | Zurich, Switzerland | no | 24 March 2026 | [Link](https://vdt26.cfp.dev/) (Opens 13 October 2025, Closes 1 December 2025) |
 | [Spring I/O](https://2025.springio.net/) | Barcelona, Spain | no | 13-15 April 2026 | - |
-| [JCON EUROPE](https://2026.europe.jcon.one/) | Cologne, Germany | no | 20-23 April 2026 | [Link](https://sessionize.com/jcon-europe-2026) (Opens 09 September 2025, Closes 24 October 2025) |
+| [JCON EUROPE](https://2026.europe.jcon.one/) | Cologne, Germany | no | 20-23 April 2026 | [Link](https://sessionize.com/jcon-europe-2026) (Closes 24 October 2025) 🟢 |
 | [Devoxx France](http://devoxx.fr/) | Paris, France | no | 20-24 April 2026 | - |
 | [Devoxx Greece](https://devoxx.gr/) | Athens, Greece | no | 23-25 April 2026 | - |
 | [Devoxx UK](https://www.devoxx.co.uk) | London, UK | no | 6-7 May 2026 | - |


### PR DESCRIPTION
Minor adjustment on the existing entry of JCON '26 as the CfP opened six hours ago.