### PR TITLE
Java Day Istanbul 2026

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Missing a conference, seeing an issue or something needs an update? Send a pull 
 | [Voxxed Days Zurich](https://zurich.voxxeddays.com/) | Zurich, Switzerland | no | 24 March 2026 | [Link](https://vdt26.cfp.dev/) (Opens 13 October 2025, Closes 1 December 2025) |
 | [Voxxed Days Amsterdam](https://amsterdam.voxxeddays.com/) | Amsterdam, The Netherlands | no | 1-2 April 2026 | - |
 | [Spring I/O](https://2025.springio.net/) | Barcelona, Spain | no | 13-15 April 2026 | - |
+| [Java Day Istanbul](https://javaday.istanbul) | Istanbul, Turkiye | no | 18 April 2026 | [Link](https://www.papercall.io/javadayistanbul2026) (Closed 31 December 2025) |
 | [JCON EUROPE](https://2026.europe.jcon.one/) | Cologne, Germany | no | 20-23 April 2026 | [Link](https://sessionize.com/jcon-europe-2026) (Closes 10 October 2025) 🟢 |
 | [Devoxx France](http://devoxx.fr/) | Paris, France | no | 20-24 April 2026 | - |
 | [Devoxx Greece](https://devoxx.gr/) | Athens, Greece | no | 23-25 April 2026 | - |


### PR DESCRIPTION

Java Day Istanbul is one of the most effective international community driven software conference of Türkiye supported by Istanbul Java User Group. The conference helps developers to learn the newest technologies about Java, Web, Mobile, Big DATA, Cloud, DevOps, Agile and Future. Java Day Istanbul also helps developers, tech companies, and startups to establish a good network among them.