### PR TITLE
fix: correctly add green ball when CFP opens and replace Closes with Closed when it closes

### DIFF
--- a/.github/scripts/check_cfp.java
+++ b/.github/scripts/check_cfp.java
@@ -62,7 +62,7 @@ class CheckCfp {
         if (isOpen && !hasGreen) {
             return before + " " + GREEN_BALL + after;
         } else if (!isOpen && hasGreen) {
-            return before + after.replace(" " + GREEN_BALL, "").replace(GREEN_BALL, "").replace("Closes", "Closed");
+            return before.replace("Closes", "Closed") + after.replace(" " + GREEN_BALL, "").replace(GREEN_BALL, "");
         }
         return line;
     }


### PR DESCRIPTION
The `updateLine` method in `check_cfp.java` had a bug in the remove branch: `.replace("Closes", "Closed")` was applied to `after` (the text after the matched date pattern), but the word "Closes" is part of the matched pattern itself which ends up in `before`. The replacement therefore never had any effect.

The fix moves the replacement to `before`.

The four cases now behave correctly:

1. CFP is open, no green ball present — green ball is added after the date: `(Closes 30 June 2026) 🟢`
2. CFP is open, green ball already present — line is left unchanged
3. CFP is closed, green ball is present — green ball is removed and "Closes" is replaced with "Closed": `(Closed 11 May 2026)`
4. CFP is closed, no green ball present — line is left unchanged