### PR TITLE
Redeploy Github pages on CFP status changes

### DIFF
--- a/.github/workflows/cfp-checker.yml
+++ b/.github/workflows/cfp-checker.yml
@@ -3,7 +3,7 @@ name: CFP Status Checker
 on:
   schedule:
     - cron: '0 6 * * *'  # Every day at 06:00 UTC
-  workflow_dispatch:       # Allow manual runs from the Actions tab
+  workflow_dispatch:
 
 jobs:
   check-cfp:
@@ -39,8 +39,6 @@ jobs:
             echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
 
-      # The commit above carries [skip ci], so the push does not trigger the
-      # Github pages deploy. Dispatch it explicitly when the README changed.
       - name: Deploy Github pages
         if: steps.commit.outputs.changed == 'true'
         env:

--- a/.github/workflows/cfp-checker.yml
+++ b/.github/workflows/cfp-checker.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       contents: write
-      actions: write   # needed to dispatch the Github pages workflow
+      actions: write
 
     steps:
       - name: Checkout

--- a/.github/workflows/cfp-checker.yml
+++ b/.github/workflows/cfp-checker.yml
@@ -10,6 +10,7 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       contents: write
+      actions: write   # needed to dispatch the Github pages workflow
 
     steps:
       - name: Checkout
@@ -25,10 +26,23 @@ jobs:
         run: echo 'CheckCfp.main();/exit' | jshell --startup .github/scripts/check_cfp.java
 
       - name: Commit changes
+        id: commit
         run: |
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
-          git diff --quiet && echo "No changes to commit." || \
-            (git add README.md && \
-             git commit -m "chore: update CFP open/closed status [skip ci]" && \
-             git push)
+          if git diff --quiet; then
+            echo "No changes to commit."
+          else
+            git add README.md
+            git commit -m "chore: update CFP open/closed status [skip ci]"
+            git push
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      # The commit above carries [skip ci], so the push does not trigger the
+      # Github pages deploy. Dispatch it explicitly when the README changed.
+      - name: Deploy Github pages
+        if: steps.commit.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh workflow run gh-pages.yml --ref main

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:       # Allow manual runs and dispatch from other workflows
 
 jobs:
   build-and-deploy:

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-  workflow_dispatch:       # Allow manual runs and dispatch from other workflows
+  workflow_dispatch:
 
 jobs:
   build-and-deploy:


### PR DESCRIPTION
The daily CFP checker commits README status updates with `[skip ci]`, which suppresses the `gh-pages` deploy, so the live site never refreshes on its own between manual merges. This wires the checker to trigger the deploy directly whenever it produces changes: `gh-pages.yml` gains a `workflow_dispatch` trigger, and `cfp-checker.yml` gets `actions: write` plus a final step that runs `gh workflow run gh-pages.yml --ref main` only when the README actually changed.