### PR TITLE
Mark W-JAX CFP as closed and harden the CFP checker

### DIFF
--- a/.github/scripts/check_cfp.java
+++ b/.github/scripts/check_cfp.java
@@ -61,7 +61,7 @@ class CheckCfp {
 
         if (isOpen && !hasGreen) {
             return before + " " + GREEN_BALL + after;
-        } else if (!isOpen && hasGreen) {
+        } else if (!isOpen && (hasGreen || before.contains("Closes"))) {
             return before.replace("Closes", "Closed") + after.replace(" " + GREEN_BALL, "").replace(GREEN_BALL, "");
         }
         return line;

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Missing a conference, seeing an issue, or something needs an update? Send a pull
 | [BaselOne](https://baselone.org/) | Basel, Switzerland | no | 14-15 October 2026 | [Link](https://sessionize.com/baselone-2026/) (Closed 30 April 2026) |
 | [jDD](https://jdd.org.pl/) | Krakow, Poland | no | 20-21 October 2026 | [Link](https://jdd.org.pl/cfp-2026/) (Closed 30 June 2026) |
 | [J On The Beach](https://www.jonthebeach.com/) | Torremolinos, Spain | yes | 29-30 October 2026 | [Link](https://confeti.app/) (Closed 31 March 2026) |
-| [W-JAX](https://jax.de/muenchen/) | Munich, Germany | yes | 2-6 November 2026 | [Link](https://callforpapers.sandsmedia.com/) (Closes 11 May 2026) |
+| [W-JAX](https://jax.de/muenchen/) | Munich, Germany | yes | 2-6 November 2026 | [Link](https://callforpapers.sandsmedia.com/) (Closed 11 May 2026) |
 | [Devoxx Morocco](https://devoxx.ma/) | Casablanca, Morocco | no | 4-5 November 2026 | [Link](https://dvma26.cfp.dev/) (Closed 5 July 2026) |
 | [Øredev](https://oredev.org/) | Malmö, Sweden | no | 4-6 November 2026 | [Link](https://sessionize.com/oredev-2026/) (Closed 31 March 2026) |
 | [Heapcon](https://heapcon.io/2026) | Belgrade, Serbia | no | 5-6 November 2026 | [Link](https://forms.gle/QBM1aqkL8yS4c6YM8) (Closed 1 June 2026) |


### PR DESCRIPTION
## Why

The W-JAX 2026 CFP closed on 11 May 2026, but its README line was stuck reading "Closes" with no 🟢 — a state the CFP-checker script could not recover from.

**Root cause:** an earlier version of `check_cfp.java` (the one that ran on 2026-05-12) removed the green ball when the CFP closed but applied the `Closes` → `Closed` rename to the wrong substring, so the ball was stripped while the word "Closes" stayed. That bug was later corrected, but the fixed script only renames `Closes` → `Closed` in the same branch that removes a green ball. Since W-JAX no longer had a ball, that branch never fired and the line was frozen.

## What

- **Fix the data:** mark the W-JAX 2026 line as `Closed`.
- **Harden the script:** the close-branch condition now fires for any past-dated CFP that still says "Closes", with or without a green ball, so a line left inconsistent by a past bug can self-correct:

  ```java
  } else if (!isOpen && (hasGreen || before.contains("Closes"))) {
  ```

## Verification

Tested `updateLine` (with `today = 2026-07-11`) across four cases: the stuck W-JAX line now renames to `Closed`; the normal has-🟢 close still works; a future CFP still gains a 🟢; and an already-`Closed` line is left untouched (idempotent).