### PR TITLE
feat: add JJUG CCC 2026 Fall conference details

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Missing a conference, seeing an issue, or something needs an update? Send a pull
 | [Porto Tech Hub](https://portotechhub.com/conference-2026/) | Porto, Portugal | no | 10 November 2026 | [Link](https://sessionize.com/pth-2026/) (Closed 14 June 2026) |
 | [J-Fall](https://jfall.nl) | Ede, Netherlands | no | 11-12 November 2026 | [link](https://sessionize.com/jfall26) (Closes 1 September 2026) 🟢 |
 | [ASF Community Over Code / ChurConf](https://au.churconf.com) | Sydney, Australia | no | 18-19 November 2026 | [Link](https://tinyurl.com/asfchurconfcfp) (Closed 31 July 2026) |
+| JJUG CCC 2026 Fall | Tokyo, Japan | no | 28 November 2026 | [Link](https://sessionize.com/jjug-ccc-2026-fall/) (Closes 31 August 2026) 🟢 |
 | [JakartaOne Livestream 2026](https://jakartaone.jakarta.ee/jakartaone-livestream-2026/) | online | no | 1 December 2026 | [Link](https://sessionize.com/jakartaone-livestream-2026/) (Closes 8 September 2026) 🟢 |
 
 ### 2027


### PR DESCRIPTION
This pull request adds a new conference to the list in the `README.md` file.

- Conferences update:
  * Added "JJUG CCC 2026 Fall" (Tokyo, Japan) with date, link, and CFP deadline to the conferences table.