### PR TITLE
Add Java Day Istanbul 2027

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,14 @@ Missing a conference, seeing an issue or something needs an update? Send a pull 
 
 
 
+### 2027
+
+| Conference | Location | Hybrid | (Expected) Date | CFP Link |
+| --- | --- | ---: | ---: | --- |
+| [Java Day Istanbul](https://javaday.istanbul) | Istanbul, Turkiye | no | 17 April 2027 | - |
+
+
+
 ### 2025
 
 | Conference | Location | Hybrid | (Expected) Date | CFP Link |

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Missing a conference, seeing an issue or something needs an update? Send a pull 
 
 | Conference | Location | Hybrid | (Expected) Date | CFP Link |
 | --- | --- | ---: | ---: | --- |
-| [Java Day Istanbul](https://javaday.istanbul) | Istanbul, Turkiye | no | 17 April 2027 | - |
+| [Java Day Istanbul](https://javaday.istanbul) | Istanbul, Turkiye | no | 17 April 2027 | [Link](https://bilgi711.wixforms.com/f/7479128754174821378) |
 
 
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Missing a conference, seeing an issue or something needs an update? Send a pull 
 
 | Conference | Location | Hybrid | (Expected) Date | CFP Link |
 | --- | --- | ---: | ---: | --- |
-| [Java Day Istanbul](https://javaday.istanbul) | Istanbul, Turkiye | no | 17 April 2027 | [Link](https://bilgi711.wixforms.com/f/7479128754174821378) |
+| [Java Day Istanbul](https://javaday.istanbul) | Istanbul, Turkiye | no | 17 April 2027 | [Link](https://bilgi711.wixforms.com/f/7479128754174821378) (Closes 31 October 2026) 🟢 |
 
 
 


### PR DESCRIPTION
Adds Java Day Istanbul 2027 (17 April 2027, Istanbul, Turkiye) to the conference list.