### PR TITLE
Move Java Day Istanbul 2027 out of Archive into 2027 section

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,18 +80,12 @@ Missing a conference, seeing an issue, or something needs an update? Send a pull
 | [Voxxed Days CERN](https://cern.voxxeddays.ch/) | Geneva, Switzerland | no | 5 March 2027 | - |
 | [Voxxed Days Zurich](https://zurich.voxxeddays.ch/) | Zurich, Switzerland | no | 9 March 2027 | - |
 | [Digital Crafts Day](https://dc-nordoberpfalz.de/DigitalCraftsDay/2027) | Weiden, Germany | no | 16 April 2027 | - |
+| [Java Day Istanbul](https://javaday.istanbul) | Istanbul, Turkiye | no | 17 April 2027 | [Link](https://bilgi711.wixforms.com/f/7479128754174821378) (Closes 31 October 2026) 🟢 |
 | [JCON EUROPE](https://2027.europe.jcon.one/) | Cologne, Germany | no | 26-29 April 2027 | - |
 | [JAlba](https://jalba.scot/) | Edinburgh, Scotland | no | 20-22 May 2027 | Unconference, no CFP |
 
 
 ## Archive
-
-### 2027
-
-| Conference | Location | Hybrid | (Expected) Date | CFP Link |
-| --- | --- | ---: | ---: | --- |
-| [Java Day Istanbul](https://javaday.istanbul) | Istanbul, Turkiye | no | 17 April 2027 | [Link](https://bilgi711.wixforms.com/f/7479128754174821378) (Closes 31 October 2026) 🟢 |
-
 
 
 ### 2025


### PR DESCRIPTION
The previous merge (#322) landed Java Day Istanbul 2027 under the Archive section's own stray 2027 subsection because my fork was based on an older README layout. This moves it into the real, chronologically-ordered ### 2027 table and removes the leftover Archive/2027 subsection.